### PR TITLE
Fix localhost build failure due to template render error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ git push heroku master # must be a contributor
 ```
 
 ## Contributing
-Send us a pull request here on Github.
+Send us a [pull request here](https://github.com/codefellows/Full-Stack-JavaScript-Engineering/pulls) on Github.
 
 More info, see the [GitBook README](https://github.com/GitbookIO/gitbook/blob/master/README.md)

--- a/backbone/routers.md
+++ b/backbone/routers.md
@@ -10,7 +10,7 @@ file in that folder with the following code:
 ```javascript
 var Backbone = require('backbone');
 var $ = require('jquery');
-Backboe.$ = $;
+Backbone.$ = $;
 var Note = require('../models/Note');
 var SimpleNoteView = require('../views/SimpleView');
 var NotesCollection = require('../collections/NotesCollection');
@@ -35,7 +35,7 @@ module.exports = Backbone.Router.extend({
 Alright, there are a lot of new concepts in this short segment of code.
 The Router always has a routes parameter that actually sets up the routes
 that are available to our application. This routes parameter is a json object
-that takes the url to hit from our base and the name of a function to call when 
+that takes the url to hit from our base and the name of a function to call when
 that base in navigated to. In the index function we create both the notes
 collection and the notes collection view and save them to the router.
 We will eventually change this to occur on initialize but for now we only have

--- a/backbone/views.md
+++ b/backbone/views.md
@@ -1,20 +1,8 @@
 Backbone Views
 ==================
-The next important component in a backbone app is the views/templates.
-These dictate how the data from the models are actually displayed.
-Each backbone component is actually composed of two different pieces.
-First, the template, which is usually a special kind of html file that
-allows you to run javascript code in it. Second, the actual view object
-that tells backbone how to actually render that html template. So the
-first step is going to be to make directories to contain both our views
-and our templates `mkdir app/js/notes/templates && mkdir app/js/notes/views`.
+The next important component in a backbone app is the views/templates. These dictate how the data from the models are actually displayed. Each backbone component is actually composed of two different pieces. First, the template, which is usually a special kind of html file that allows you to run javascript code in it. Second, the actual view object that tells backbone how to actually render that html template. So the first step is going to be to make directories to contain both our views and our templates `mkdir app/js/notes/templates && mkdir app/js/notes/views`.
 
-Next we have to actually install the templating engine and tell browserify
-how to talk to it. I prefer <a href="http://handlebarsjs.com/">handlebars</a>
-for my templating engine. It's easy to understand and surprisingly powerful.
-We're going to actually install the browserify transform hbsfy which is a browserify
-plugin used to render hbs templates. `npm install --save-dev hbsfy`. Then change
-your browserify task in your Gruntfile.js to look like this:
+Next we have to actually install the templating engine and tell browserify how to talk to it. I prefer <a href="http://handlebarsjs.com/">handlebars</a> for my templating engine. It's easy to understand and surprisingly powerful. We're going to actually install the browserify transform hbsfy which is a browserify plugin used to render hbs templates. `npm install --save-dev hbsfy`. Then change your browserify task in your Gruntfile.js to look like this:
 ```javascript
 browserify: {
   dist: {
@@ -26,19 +14,14 @@ browserify: {
   }
 }
 ```
-This tells browserify to run the appropriate files through hbsfy which processes
-the handlebars specific lines. For our Note the template is going to be very
-simple. Create a file called simpleView.hbs in app/js/notes/templates that
-contains the following:
+This tells browserify to run the appropriate files through hbsfy which processes the handlebars specific lines. For our Note the template is going to be very simple. Create a file called simpleView.hbs in app/js/notes/templates that contains the following:
+
 ```javascript
 <h1>{{noteBody}}</h1>
 ```
-The handlebars templates contain html code with javascript executed in {{}} blocks.
-In our case we just want to display the noteBody of the model we are currently 
-rendering.
+The handlebars templates contain html code with javascript executed in double brace blocks. In our case we just want to display the noteBody of the model we are currently rendering.
 
-Next create a file named SimpleView.js in app/js/notes/views/ with the 
-following code:
+Next create a file named SimpleView.js in app/js/notes/views/ with the following code:
 ```javascript
 var Backbone = require('backbone');
 var $ = require('jquery');
@@ -58,30 +41,9 @@ module.exports = Backbone.View.extend({
   }
 );
 ```
-Alright, there's quite a bit going on in this file. First, we pull in backbone
-and jquery then we have to set backbone's internal reference to jquery to the
-jquery library we pulled in. This is something specific to browserify and it 
-isn't necessary with other backbone implementations. Inside of our view object
-we first have a tagName. This is the tag that our entire view will be wrapped it.
-It could easily be a li element or a section or really any html tag that we want.
-For simplicity, I have chosen a div tag. Next, the initialize function gets called
-whenever a new instance of this view is created. For this view we really only want
-to render the view internally, so we call the render function. In the render
-function we first pull in the template that we created earlier and set it 
-to a variable named(surprise) template. Often you will see this template saved to
-a parameter of the view object rather than a variable in the render function but
-this pattern doesn't work with browserify. The next line is the real meat of the 
-view. Each view has an el element that contains all of the html for the view. The
-$el lets us take advantage of jQuery functions such as the .html function. Whenever
-we render something to the DOM this is the element we use to do it. In this case
-we're passing the attributes of our model to the template we defined and rendering
-it as html. The last step is to return the copy of the view that we're currently 
-working on. This updates the reference to the current view after we're done 
-manipulating it.
+Alright, there's quite a bit going on in this file. First, we pull in backbone and jquery then we have to set backbone's internal reference to jquery to the jquery library we pulled in. This is something specific to browserify and it isn't necessary with other backbone implementations. Inside of our view object we first have a tagName. This is the tag that our entire view will be wrapped it. It could easily be a li element or a section or really any html tag that we want. For simplicity, I have chosen a div tag. Next, the initialize function gets called whenever a new instance of this view is created. For this view we really only want to render the view internally, so we call the render function. In the render function we first pull in the template that we created earlier and set it to a variable named(surprise) template. Often you will see this template saved to a parameter of the view object rather than a variable in the render function but this pattern doesn't work with browserify. The next line is the real meat of the view. Each view has an el element that contains all of the html for the view. The $el lets us take advantage of jQuery functions such as the .html function. Whenever we render something to the DOM this is the element we use to do it. In this case we're passing the attributes of our model to the template we defined and rendering it as html. The last step is to return the copy of the view that we're currently working on. This updates the reference to the current view after we're done manipulating it.
 
-After we create our view the next step is to actually render it to the dom. First
-add the following line in the body tag of index.html(make sure you edit the one in
-app and not the one in dist).
+After we create our view the next step is to actually render it to the dom. First add the following line in the body tag of index.html(make sure you edit the one in app and not the one in dist).
 ```html
 <div id="backbone-content"></div>
 ```
@@ -96,11 +58,6 @@ var simpleView = new SimpleView({model: Note});
 
 $('#backbone-content').append(simpleView.el);
 ```
-Now if we build this and open it in the browser we should see 'hello world' in large
-friendly letters(friendliness may vary). Notice that when we create the view that
-we pass our instance note to it as a model parameter. This is so we can 
-reference this.model from within the view. When our view is created it automatically
-renders it as defined in the initialize function and then we can just append it
-to our backbone-content div and it'll be loaded in the dom.
+Now if we build this and open it in the browser we should see 'hello world' in large friendly letters(friendliness may vary). Notice that when we create the view that we pass our instance note to it as a model parameter. This is so we can reference this.model from within the view. When our view is created it automatically renders it as defined in the initialize function and then we can just append it to our backbone-content div and it'll be loaded in the dom.
 
 Well, that's it on views for now.

--- a/day8/superagent_testing.md
+++ b/day8/superagent_testing.md
@@ -1,12 +1,12 @@
 Testing with Super Agent
 ===============================
-Super Agent is a tool to make REST requests from within Node. It makesthe sending requests
-as easy as .put or .get, much in the same way that express allows you to simplify the handling
+Super Agent is a tool to make REST requests from within Node. It makes the sending requests
+as easy as `.put` or `.get`, much in the same way that express allows you to simplify the handling
 of incoming REST requests. While Super Agent is not specifically designed to test JSON apis,
 it greatly simplifies acceptance testing of said JSON apis. Testing using Super Agent requires
 both a testing framework, as well as a collection of expect statements. Also being able to run
 tests from Grunt is key. A combination of Mocha and Chai should fit the bill nicely. First run
-`npm install superagent chai mocha --save` then create a test file test/api/notes_api_test.js with the
+`npm install superagent chai mocha --save` then create a test file entitled `test/api/notes_api_test.js` with the
 following code:
 ```javascript
 var superagent = require('superagent');
@@ -70,4 +70,4 @@ describe('Notes JSON api', function() {
   });
 });
 ```
-Some interesting things happen in this code, first when app is required from server.js it actually starts the server before sending JSON requests to it. When each request is sent to the server it returns a callback response that should contain a successful JSON object.  In the case of the creation of this object(the POST request) it returns a copy of the object that presumably has been saved to a persistent database. It's integration testing, so while it's not precise it does test the general use case for the JSON api.```')})})```
+Some interesting things happen in this code, first when app is required from server.js it actually starts the server before sending JSON requests to it. When each request is sent to the server it returns a callback response that should contain a successful JSON object.  In the case of the creation of this object(the POST request) it returns a copy of the object that presumably has been saved to a persistent database. It's integration testing, so while it's not precise it does test the general use case for the JSON api.

--- a/hello-world-node/async_demo.md
+++ b/hello-world-node/async_demo.md
@@ -15,12 +15,12 @@ process.nextTick(function() {
 truth_value = true;
 ```
 
-What will the output be? False or True?
+What will the output be? `false` or `true`?
 
-The answer is that the output will be true. Why? You might have thought
-it would be false, right? It's like the statements are having out of order.
+The answer is that the output will be `true`. Why? You might have thought
+it would be `false`, right? It's like the statements are having out of order.
 
-It's because we are placing our function with conosole.log on the event queue. 
+It's because we are placing our function with `console.log` on the event queue. Read more about [`process.nextTick`](https://nodejs.org/api/process.html#process_process_nexttick_callback).
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "Full-Stack-JavaScript-Engineering",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "backbone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
+      "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+      "requires": {
+        "underscore": "1.8.3"
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Textbook for Code Fellows JavaScript Development Accelerator",
   "main": "server.js",
   "dependencies": {
+    "backbone": "^1.3.3",
     "express": "^4.1.1",
+    "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt": "^0.4.5",
     "grunt-gh-pages": "^0.9.1",
     "grunt-gitbook": "^0.4.2",
     "node-static": "^0.7.3"

--- a/setup/install_node_from_source.md
+++ b/setup/install_node_from_source.md
@@ -12,7 +12,7 @@ This is only if you need to, generally just on Linux systems.
 ```
 tar -xvf <the node tar.gz you downloaded>
 cd <node directory>
-./configure --prefix=~/.node
+./configure --prefix=$HOME/.node
 make && make install
 ```
 
@@ -20,6 +20,12 @@ make && make install
 ```
 export PATH=$PATH:$HOME/.node/bin
 export NODE_PATH=$HOME/.node/lib/node_modules
+```
+
+or for fish, add the following to config.fish (~/.config/fish/config.fish)
+```
+set -gx PATH $PATH $HOME/.node/bin
+set -gx NODE_PATH $HOME/.node/lib/node_modules
 ```
 
 ## Making sure it works


### PR DESCRIPTION
Attempted to build to localhost using 

$ gitbook serve .

Build failed with unexpected token error in markdown file due to presence of backbone double braces, not sure why.  Output:

<snip>
info: loading plugin "theme-default"... OK
info: found 50 pages
info: found 127 asset files
error: error while generating page "backbone/views.md":

Template render error: (/Users/imac_home/Projects/Full-Stack-JavaScript-Engineering/backbone/views.md) [Line 22, Column 99]
  unexpected token: }}

Fix was to remove these "tokens" and replace them with text in backbone/views.md file. Precise change was from this  --

>The handlebars templates contain html code with javascript executed in {{}} blocks. In our case we just want to display the noteBody of the model we are currently rendering.

-- to this:

>The handlebars templates contain html code with javascript executed in double brace blocks. In our case we just want to display the noteBody of the model we are currently rendering.

CLOSED because I noticed that pull requests should be directed to codefellows repo not ivanoats.

